### PR TITLE
Linux環境でB25Decoder.soのロードに失敗する問題の修正

### DIFF
--- a/B25Decoder/BonProject/MyWinScard.cpp
+++ b/B25Decoder/BonProject/MyWinScard.cpp
@@ -33,7 +33,7 @@ int SCardConnect(SCARDCONTEXT hContext,
                  /*@out@*/ SCARDHANDLE *phCard,
                  /*@out@*/ unsigned int *pdwActiveProtocol)
 {
-	DWORD dwActiveProtocol;
+	DWORD dwActiveProtocol = pdwActiveProtocol ? *pdwActiveProtocol : 0;
 	LONG nRet = ::SCardConnect(hContext, szReader, dwShareMode, dwPreferredProtocols,
 	                           (::SCARDHANDLE *)phCard, pdwActiveProtocol ? &dwActiveProtocol : NULL);
 	if (pdwActiveProtocol) {
@@ -54,12 +54,12 @@ int SCardTransmit(SCARDHANDLE hCard,
                   unsigned int cbSendLength,
                   /*@out@*/ void *pioRecvPci,
                   /*@out@*/ BYTE *pbRecvBuffer,
-                  unsigned int *pcbRecvLength)
+                  /*@in,out@*/ unsigned int *pcbRecvLength)
 {
 	if (pioSendPci || pioRecvPci) {
 		return (int)SCARD_E_INVALID_PARAMETER;
 	}
-	DWORD cbRecvLength;
+	DWORD cbRecvLength = pcbRecvLength ? *pcbRecvLength : 0;
 	LONG nRet = ::SCardTransmit(hCard, SCARD_PCI_T1, pbSendBuffer, cbSendLength, NULL,
 	                            pbRecvBuffer, pcbRecvLength ? &cbRecvLength : NULL);
 	if (pcbRecvLength) {
@@ -71,9 +71,9 @@ int SCardTransmit(SCARDHANDLE hCard,
 int SCardListReaders(SCARDCONTEXT hContext,
                      /*@null@*/ /*@out@*/ LPCSTR mszGroups,
                      /*@null@*/ /*@out@*/ LPSTR mszReaders,
-                     /*@out@*/ unsigned int *pcchReaders)
+                     /*@in,out@*/ unsigned int *pcchReaders)
 {
-	DWORD cchReaders;
+	DWORD cchReaders = pcchReaders ? *pcchReaders : 0;
 	LONG nRet = ::SCardListReaders(hContext, mszGroups, mszReaders, pcchReaders ? &cchReaders : NULL);
 	if (pcchReaders) {
 		*pcchReaders = (unsigned int)cchReaders;

--- a/B25Decoder/BonProject/MyWinScard.h
+++ b/B25Decoder/BonProject/MyWinScard.h
@@ -67,10 +67,10 @@ int SCardTransmit(SCARDHANDLE hCard,
                   unsigned int cbSendLength,
                   /*@out@*/ void *pioRecvPci, // NULLであること
                   /*@out@*/ BYTE *pbRecvBuffer,
-                  unsigned int *pcbRecvLength);
+                  /*@in,out@*/ unsigned int *pcbRecvLength);
 
 int SCardListReaders(SCARDCONTEXT hContext,
                      /*@null@*/ /*@out@*/ LPCSTR mszGroups,
                      /*@null@*/ /*@out@*/ LPSTR mszReaders,
-                     /*@out@*/ unsigned int *pcchReaders);
+                     /*@in,out@*/ unsigned int *pcchReaders);
 }


### PR DESCRIPTION
## 概要

Linux環境において、B25Decoder.soのロードに失敗する問題を修正しました。

Linux環境において、EDCBをバージョンアップしたところ、それまで正常に機能していたB25デコード処理に失敗する事例が5chで報告されました。

該当レス：[https://mao.5ch.net/test/read.cgi/linux/1695289122/992](https://mao.5ch.net/test/read.cgi/linux/1695289122/992)

興味深い内容だったので調査した結果、`SCardTransmit`関数がバッファサイズ不足を示す`SCARD_E_INSUFFICIENT_BUFFER`エラーを返したことが、`B25Decoder.so`のロード失敗の原因であることがわかりました。このエラーは、`SCardTransmit`関数の引数である`pcbRecvLength`が適切に設定されていないため発生します。

## 問題点

`SCardTransmit`関数のリファレンスを示します。

[https://learn.microsoft.com/ja-jp/windows/win32/api/winscard/nf-winscard-scardtransmit](https://learn.microsoft.com/ja-jp/windows/win32/api/winscard/nf-winscard-scardtransmit)

> `[in, out] pcbRecvLength`
>
> `pbRecvBuffer` パラメーターの長さをバイト単位で指定し、スマートカードから受信した実際のバイト数を受け取ります。

`SCardTransmit`関数を呼び出している以下のコードに問題があります。

[https://github.com/tsukumijima/Multi2Dec/blob/e709331d812ee410ca7ad3e3919d1b55e21ef678/B25Decoder/BonProject/MyWinScard.cpp#L62-L64](https://github.com/tsukumijima/Multi2Dec/blob/e709331d812ee410ca7ad3e3919d1b55e21ef678/B25Decoder/BonProject/MyWinScard.cpp#L62-L64)

`SCardTransmit`関数リファレンスでは、受信用バッファ`pbRecvBuffer`のサイズを指すように`pcbRecvLength`を設定する必要があります。しかし、実際には初期化されていないローカル変数`cbRecvLength`のアドレスが`pcbRecvLength`に渡されています。ローカル変数の初期値は不定であるため、必要なバッファサイズよりも小さい値の場合、`SCARD_E_INSUFFICIENT_BUFFER`エラーが発生し`B25Decoder.so`のロードに失敗します。

## 変更点

`pcbRecvLength`が`nullptr`でない場合に、`pcbRecvLength`が指す値をローカル変数`cbRecvLength`の初期値として設定するように修正しました。

```cpp
DWORD cbRecvLength = pcbRecvLength ? *pcbRecvLength : 0;
```

また、`SCardListReaders`関数の`pcchReaders`引数も`[in,out]`であるため同様の修正を行い、`SCardConnect`関数の`dwActiveProtocol`引数は`[out]`ですが、同様に修正しました。

## 動作確認

以下のLinux環境でB25デコード処理が可能なことを確認しました。

* Ubuntu Server 24.04.2
* [EDCB work-plus-s-250321](https://github.com/xtne6f/EDCB/tree/work-plus-s-250321)
